### PR TITLE
Implemented access log

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.21.4' ]
+        go-version: [ '1.21.6' ]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go ${{ matrix.go-version }}

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.21.x' ]
+        go-version: [ '1.21.6' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.21.x' ]
+        go-version: [ '1.21.6' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.21.x' ]
+        go-version: [ '1.21.6' ]
     steps:
       - uses: actions/checkout@v4
+      - name: Add hosts to /etc/hosts
+        # For testing purposes, we need to add the hosts to /etc/hosts
+        run: (echo "127.0.0.1 backend1.local" && echo "127.0.0.1 backend2.local") | sudo tee -a /etc/hosts
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v4
         with:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ go get -u github.com/bmf-san/gondola
 See below for how to use gondola.
 
 - [_examples](https://github.com/bmf-san/gondola/tree/main/_examples)
-- [example_gondola_test.go](https://github.com/bmf-san/gondola/tree/main/example_gondola_test.go)
 
 # Usage
 // TODO: edit later

--- a/_examples/backend1/Dockerfile
+++ b/_examples/backend1/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.0-alpine
+FROM golang:1.21.6-alpine
 
 WORKDIR /app
 

--- a/_examples/backend1/main.go
+++ b/_examples/backend1/main.go
@@ -3,12 +3,19 @@ package main
 import (
 	"log"
 	"net/http"
+	"time"
 )
 
 func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		log.Print("backend1 sleep 1 seconds")
+		time.Sleep(3 * time.Second)
+		log.Print(r.Header)
 		w.Write([]byte("Hello from backend1"))
+	})
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("backend1 is OK"))
 	})
 	if err := http.ListenAndServe(":8081", mux); err != nil {
 		log.Fatal(err)

--- a/_examples/backend2/Dockerfile
+++ b/_examples/backend2/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.0-alpine
+FROM golang:1.21.6-alpine
 
 WORKDIR /app
 

--- a/_examples/backend2/main.go
+++ b/_examples/backend2/main.go
@@ -3,12 +3,19 @@ package main
 import (
 	"log"
 	"net/http"
+	"time"
 )
 
 func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		log.Print("backend2 sleep 2 seconds")
+		time.Sleep(5 * time.Second)
+		log.Print(r.Header)
 		w.Write([]byte("Hello from backend2"))
+	})
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("backend2 is OK"))
 	})
 	if err := http.ListenAndServe(":8082", mux); err != nil {
 		log.Fatal(err)

--- a/_examples/proxy/Dockerfile
+++ b/_examples/proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.0-alpine
+FROM golang:1.21.6-alpine
 
 WORKDIR /app
 

--- a/_examples/proxy/config.yaml
+++ b/_examples/proxy/config.yaml
@@ -7,3 +7,4 @@ upstreams:
     target: http://backend1:8081 # backend1　is the name of the container
   - host_name: backend2.local
     target: http://backend2:8082 # backend2　is the name of the container
+log_level: 0 # Debug:-4 Info:0 Warn:4 Error:8

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,11 +18,9 @@ func init() {
 }
 
 func main() {
-	l := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-
 	defer func() {
 		if x := recover(); x != nil {
-			l.Error(string(debug.Stack()))
+			slog.Error(string(debug.Stack()))
 		}
 		os.Exit(1)
 	}()
@@ -35,27 +33,27 @@ func main() {
 	}
 
 	if cfgFile == "" {
-		l.Error("config file is not specified")
+		slog.Error("config file is not specified")
 		os.Exit(1)
 	}
 
 	cfg, err := os.Open(filepath.Clean(cfgFile))
 	if err != nil {
-		l.Error(err.Error())
+		slog.Error(err.Error())
 		os.Exit(1)
 	}
 
 	defer func() {
 		err = cfg.Close()
 		if err != nil {
-			l.Error(err.Error())
+			slog.Error(err.Error())
 			os.Exit(1)
 		}
 	}()
 
-	gondola, err := gondola.NewGondola(l, cfg)
+	gondola, err := gondola.NewGondola(cfg)
 	if err != nil {
-		l.Error(err.Error())
+		slog.Error(err.Error())
 		os.Exit(1)
 	}
 

--- a/config.go
+++ b/config.go
@@ -27,6 +27,7 @@ type Upstream struct {
 type Config struct {
 	Proxy     Proxy      `yaml:"proxy"`
 	Upstreams []Upstream `yaml:"upstreams"`
+	LogLevel  int        `yaml:"log_level"` // Debug:-4 Info:0 Warn:4 Error:8
 }
 
 // Load reads the configuration from a reader and returns a Config struct.

--- a/config_test.go
+++ b/config_test.go
@@ -17,6 +17,7 @@ upstreams:
     target: http://backend1:8081
   - host_name: backend2.local
     target: http://backend2:8082
+log_level: -4
 `
 
 	expected := &Config{
@@ -35,6 +36,7 @@ upstreams:
 				Target:   "http://backend2:8082",
 			},
 		},
+		4,
 	}
 
 	actual := &Config{}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/bmf-san/gondola
 
 go 1.21
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require (
+	github.com/google/uuid v1.5.0
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,6 @@
+github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
+github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,55 @@
+package gondola
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/google/uuid"
+)
+
+// Logger is a logger.
+type Logger struct {
+	*slog.Logger
+}
+
+// NewLogger creates a logger.
+func NewLogger(level int) *Logger {
+	handler := TraceIDHandler{slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.Level(level),
+	})}
+	logger := slog.New(handler)
+	return &Logger{
+		logger,
+	}
+}
+
+// WithTraceID adds a trace ID to the context.
+func WithTraceID(ctx context.Context) context.Context {
+	uuid, _ := uuid.NewRandom()
+	return context.WithValue(ctx, ctxTraceIDKey, uuid.String())
+}
+
+// GetTraceID returns a trace ID from the context.
+func GetTraceID(ctx context.Context) string {
+	tid, _ := ctx.Value(ctxTraceIDKey).(string)
+	return tid
+}
+
+// TraceIDHandler is a handler for trace ID.
+type TraceIDHandler struct {
+	slog.Handler
+}
+
+type ctxTraceID struct{}
+
+var ctxTraceIDKey = ctxTraceID{}
+
+// Handle adds a trace ID to the record.
+func (t TraceIDHandler) Handle(ctx context.Context, r slog.Record) error {
+	tid, ok := ctx.Value(ctxTraceIDKey).(string)
+	if ok {
+		r.AddAttrs(slog.String("trace_id", tid))
+	}
+	return t.Handler.Handle(ctx, r)
+}

--- a/logger.go
+++ b/logger.go
@@ -47,8 +47,8 @@ var ctxTraceIDKey = ctxTraceID{}
 
 // Handle adds a trace ID to the record.
 func (t TraceIDHandler) Handle(ctx context.Context, r slog.Record) error {
-	tid, ok := ctx.Value(ctxTraceIDKey).(string)
-	if ok {
+	tid := GetTraceID(ctx)
+	if tid != "" {
 		r.AddAttrs(slog.String("trace_id", tid))
 	}
 	return t.Handler.Handle(ctx, r)

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,40 @@
+package gondola
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+)
+
+func TestNewLogger(t *testing.T) {
+	level := 1
+	logger := NewLogger(level)
+	if logger == nil {
+		t.Fatal("Expected logger to be created, but got nil")
+	}
+}
+
+func TestWithAndGetTraceID(t *testing.T) {
+	ctx := WithTraceID(context.Background())
+	tid := GetTraceID(ctx)
+	if tid == "" {
+		t.Fatal("Expected trace ID to be created, but got empty string")
+	}
+}
+
+func TestHandle(t *testing.T) {
+	handler := TraceIDHandler{slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.Level(0),
+	})}
+	ctx := context.WithValue(context.Background(), ctxTraceIDKey, "12345")
+	err := handler.Handle(ctx, slog.Record{Level: slog.Level(1)})
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	ctx = context.Background()
+	err = handler.Handle(ctx, slog.Record{Level: slog.Level(1)})
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+}

--- a/proxy.go
+++ b/proxy.go
@@ -76,7 +76,7 @@ func (h *ProxyHandler) Handler(w http.ResponseWriter, r *http.Request) {
 	ctx := WithTraceID(r.Context())
 	defer func() {
 		// TODO: Is it possible to merge the logs output by roundtrip?
-		slog.InfoContext(r.Context(), "proxy_response", slog.Time("time", time.Now()), slog.String("client_ip", r.RemoteAddr), slog.String("req_x_forwarded_for", r.Header.Get("X-Forwarded-For")), slog.String("req_method", r.Method), slog.String("req_uri", r.RequestURI), slog.Int64("req_size", r.ContentLength), slog.Float64("proxy_response_time", time.Since(start).Seconds()), slog.String("referer", r.Header.Get("referer")), slog.String("req_ua", r.UserAgent()))
+		slog.InfoContext(ctx, "proxy_response", slog.Time("time", time.Now()), slog.String("client_ip", r.RemoteAddr), slog.String("req_x_forwarded_for", r.Header.Get("X-Forwarded-For")), slog.String("req_method", r.Method), slog.String("req_uri", r.RequestURI), slog.Int64("req_size", r.ContentLength), slog.Float64("proxy_response_time", time.Since(start).Seconds()), slog.String("referer", r.Header.Get("referer")), slog.String("req_ua", r.UserAgent()))
 	}()
 	h.proxy.ServeHTTP(w, r.WithContext(ctx))
 }

--- a/proxy.go
+++ b/proxy.go
@@ -113,8 +113,7 @@ func newServer(c *Config) (*http.Server, error) {
 // TODO: Need to dynamically load a configuration file. For now, we will limit the implementation to just loading the file at startup.
 // Run starts the proxy server.
 func (g *Gondola) Run() {
-	// TODO: envから読み出し log level # -4: Debug 0: Info 4: Warn 8: Error
-	logger := NewLogger(0)
+	logger := NewLogger(g.config.LogLevel)
 	slog.SetDefault(logger.Logger)
 
 	// TODO: do health check for upstreams.

--- a/proxy.go
+++ b/proxy.go
@@ -14,21 +14,16 @@ import (
 	"time"
 )
 
-// CLI is a command line interface.
-type CLI interface {
-	Run()
-}
-
 // Gondola is a proxy server.
 type Gondola struct {
-	logger *slog.Logger
 	config *Config
 	server *http.Server
 }
 
 // NewGondola returns a new Gondola.
-func NewGondola(l *slog.Logger, r io.Reader) (*Gondola, error) {
-	c, err := loadConfig(r)
+func NewGondola(r io.Reader) (*Gondola, error) {
+	cfg := &Config{}
+	c, err := cfg.Load(r)
 	if err != nil {
 		return nil, err
 	}
@@ -39,30 +34,56 @@ func NewGondola(l *slog.Logger, r io.Reader) (*Gondola, error) {
 	}
 
 	return &Gondola{
-		logger: l,
 		config: c,
 		server: s,
 	}, nil
 }
 
-// loadConfig loads a configuration file.
-func loadConfig(r io.Reader) (*Config, error) {
-	cfg := &Config{}
-	c, err := cfg.Load(r)
+// LogRoundTripper is a RoundTripper that logs the request and response.
+type LogRoundTripper struct {
+	transport http.RoundTripper
+}
+
+// NewLogRoundTripper returns a new LogRoundTripper.
+func NewLogRoundTripper(transport http.RoundTripper) *LogRoundTripper {
+	return &LogRoundTripper{transport: transport}
+}
+
+// RoundTrip implements the RoundTripper interface.
+// It logs the request and response.
+func (lrt *LogRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	start := time.Now()
+
+	resp, err := lrt.transport.RoundTrip(r)
 	if err != nil {
 		return nil, err
 	}
 
-	return c, nil
+	slog.InfoContext(r.Context(), "upstream_response", slog.Time("time", time.Now()), slog.String("client_ip", r.RemoteAddr), slog.String("req_x_forwarded_for", r.Header.Get("X-Forwarded-For")), slog.String("req_method", r.Method), slog.String("req_uri", r.RequestURI), slog.String("resp_status", resp.Status), slog.Int64("req_size", r.ContentLength), slog.Int64("resp_body_size", resp.ContentLength), slog.Float64("upstream_response_time", time.Since(start).Seconds()), slog.String("referer", r.Header.Get("referer")), slog.String("req_ua", r.UserAgent()))
+
+	return resp, nil
+}
+
+// ProxyHandler is a http.Handler that proxies the request.
+type ProxyHandler struct {
+	proxy *httputil.ReverseProxy
+}
+
+// Handler implements the http.Handler interface.
+// It proxies the request.
+func (h *ProxyHandler) Handler(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+	ctx := WithTraceID(r.Context())
+	defer func() {
+		// TODO: Is it possible to merge the logs output by roundtrip?
+		slog.InfoContext(r.Context(), "proxy_response", slog.Time("time", time.Now()), slog.String("client_ip", r.RemoteAddr), slog.String("req_x_forwarded_for", r.Header.Get("X-Forwarded-For")), slog.String("req_method", r.Method), slog.String("req_uri", r.RequestURI), slog.Int64("req_size", r.ContentLength), slog.Float64("proxy_response_time", time.Since(start).Seconds()), slog.String("referer", r.Header.Get("referer")), slog.String("req_ua", r.UserAgent()))
+	}()
+	h.proxy.ServeHTTP(w, r.WithContext(ctx))
 }
 
 // newServer returns a new http.Server.
 func newServer(c *Config) (*http.Server, error) {
-	s := &http.Server{
-		Addr:              ":" + c.Proxy.Port,
-		ReadHeaderTimeout: time.Duration(c.Proxy.ReadHeaderTimeout) * time.Millisecond,
-	}
-
+	mux := http.NewServeMux()
 	for _, b := range c.Upstreams {
 		pp, err := url.Parse(b.Target)
 		if err != nil {
@@ -70,26 +91,39 @@ func newServer(c *Config) (*http.Server, error) {
 		}
 
 		proxy := httputil.NewSingleHostReverseProxy(pp)
-		http.HandleFunc(b.HostName+"/", func(w http.ResponseWriter, r *http.Request) {
-			proxy.ServeHTTP(w, r)
-		})
+		proxy.Transport = NewLogRoundTripper(http.DefaultTransport)
+		originalDirector := proxy.Director
+		proxy.Director = func(r *http.Request) {
+			originalDirector(r)
+			r.Header.Set("X-Trace-ID", GetTraceID(r.Context()))
+		}
+		ph := &ProxyHandler{proxy: proxy}
+		mux.HandleFunc(b.HostName+"/", ph.Handler)
+	}
+
+	s := &http.Server{
+		Addr:              ":" + c.Proxy.Port,
+		ReadHeaderTimeout: time.Duration(c.Proxy.ReadHeaderTimeout) * time.Millisecond,
+		Handler:           mux,
 	}
 
 	return s, nil
 }
 
-// TODO:
-// need to dynamically load a configuration file.
-// For now, we will limit the implementation to just loading the file at startup.
+// TODO: Need to dynamically load a configuration file. For now, we will limit the implementation to just loading the file at startup.
 // Run starts the proxy server.
 func (g *Gondola) Run() {
+	// TODO: envから読み出し log level # -4: Debug 0: Info 4: Warn 8: Error
+	logger := NewLogger(0)
+	slog.SetDefault(logger.Logger)
+
 	// TODO: do health check for upstreams.
 
-	g.logger.Info("Runing server on port " + g.config.Proxy.Port + "...")
+	slog.Info("Runing server on port " + g.config.Proxy.Port + "...")
 
 	go func() {
 		if err := g.server.ListenAndServe(); err != http.ErrServerClosed {
-			g.logger.Error("Server stopped with error: " + err.Error())
+			slog.Error("Server stopped with error: " + err.Error())
 			return
 		}
 	}()
@@ -101,9 +135,9 @@ func (g *Gondola) Run() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(g.config.Proxy.ShutdownTimeout)*time.Millisecond)
 	defer cancel()
 	if err := g.server.Shutdown(ctx); err != nil {
-		g.logger.Error("Server stopped with error: " + err.Error())
+		slog.Error("Server stopped with error: " + err.Error())
 		return
 	}
 
-	g.logger.Info("Server stopped gracefully")
+	slog.Info("Server stopped gracefully")
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1,25 +1,155 @@
 package gondola
 
 import (
-	"log/slog"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
 	"net/url"
-	"os"
 	"strings"
 	"testing"
 )
 
 func TestNewGondola(t *testing.T) {
-	t.Skip("Skip it because it has been tested with TestRun")
+	data := `
+proxy:
+  port: 8080
+  read_header_timeout: 2000
+  shutdown_timeout: 3000
+upstreams:
+  - host_name: backend1.local
+    target: http://backend1:8081
+  - host_name: backend2.local
+    target: http://backend2:8082
+`
+
+	r := strings.NewReader(data)
+	gondola, err := NewGondola(r)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if gondola.config == nil {
+		t.Errorf("Expected config, got nil")
+	}
+	if gondola.server == nil {
+		t.Errorf("Expected server, got nil")
+	}
+	gondola.server.Close()
 }
 
-func TestLoadConfig(t *testing.T) {
-	t.Skip("Skip it because it has been tested with TestLoad")
+func TestNewLogRoundTripper(t *testing.T) {
+	transport := http.DefaultTransport
+	lrt := NewLogRoundTripper(transport)
+	if lrt == nil {
+		t.Errorf("Expected LogRoundTripper, got nil")
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	lrt := &LogRoundTripper{
+		transport: http.DefaultTransport,
+	}
+	dummy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("dummy"))
+	}))
+	defer dummy.Close()
+	dummyURL, err := url.Parse(dummy.URL)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	resp, err := lrt.RoundTrip(httptest.NewRequest(http.MethodGet, dummyURL.String(), nil))
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if resp == nil {
+		t.Errorf("Expected response, got nil")
+	}
+}
+
+func TestHandler(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("backend"))
+	}))
+	defer backend.Close()
+
+	backendURL, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyHandler := &ProxyHandler{
+			proxy: httputil.NewSingleHostReverseProxy(backendURL),
+		}
+		proxyHandler.Handler(w, r)
+	}))
+	defer proxy.Close()
+
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	resp, err := http.Get(proxyURL.String())
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if string(b) != "backend" {
+		t.Errorf("Expected body %s, got %s", "backend", string(b))
+	}
 }
 
 func TestNewServer(t *testing.T) {
-	t.Skip("Skip it because it has been tested with TestRun")
+	backend1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("backend1"))
+	}))
+	defer backend1.Close()
+
+	backend2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("backend2"))
+	}))
+	defer backend2.Close()
+
+	backend1URL, err := url.Parse(backend1.URL)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	backend2URL, err := url.Parse(backend2.URL)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	data := `
+proxy:
+  port: 8080
+  read_header_timeout: 2000
+  shutdown_timeout: 3000
+upstreams:
+  - host_name: backend1.local
+    target: ` + backend1URL.String() + `
+  - host_name: backend2.local
+    target: ` + backend2URL.String() + `
+`
+
+	cfg := &Config{}
+	c, err := cfg.Load(strings.NewReader(data))
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	server, err := newServer(c)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if server == nil {
+		t.Errorf("Expected server, got nil")
+	}
+	server.Close()
 }
 
 func TestRun(t *testing.T) {
@@ -54,8 +184,7 @@ upstreams:
   - host_name: backend2.local
     target: ` + backend2URL.String() + `
 `
-
-	gondola, err := NewGondola(slog.New(slog.NewJSONHandler(os.Stdout, nil)), strings.NewReader(data))
+	gondola, err := NewGondola(strings.NewReader(data))
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -73,13 +202,13 @@ upstreams:
 	}{
 		{
 			name:    "request to backend1",
-			reqPath: "http://backend1.local/",
+			reqPath: "http://backend1.local:8080/",
 			body:    "backend1",
 			code:    http.StatusOK,
 		},
 		{
 			name:    "request to backend2",
-			reqPath: "http://backend2.local/",
+			reqPath: "http://backend2.local:8080/",
 			body:    "backend2",
 			code:    http.StatusOK,
 		},
@@ -89,16 +218,22 @@ upstreams:
 			if err != nil {
 				t.Fatal(err)
 			}
-			rec := httptest.NewRecorder()
-			http.DefaultServeMux.ServeHTTP(rec, req)
-			if rec.Body.String() != test.body {
-				t.Errorf("Expected body %s, got %s", test.body, rec.Body.String())
+			res, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatal(err)
 			}
-			if rec.Code != test.code {
-				t.Errorf("Expected status code %d, got %d", test.code, rec.Code)
+			defer res.Body.Close()
+			b, err := io.ReadAll(res.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if res.StatusCode != test.code {
+				t.Errorf("Expected status code %d, got %d", test.code, res.StatusCode)
+			}
+			if string(b) != test.body {
+				t.Errorf("Expected body %s, got %s", test.body, string(b))
 			}
 		})
 	}
-
 	gondola.server.Close()
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -21,6 +21,7 @@ upstreams:
     target: http://backend1:8081
   - host_name: backend2.local
     target: http://backend2:8082
+log_level: -4
 `
 
 	r := strings.NewReader(data)
@@ -135,6 +136,7 @@ upstreams:
     target: ` + backend1URL.String() + `
   - host_name: backend2.local
     target: ` + backend2URL.String() + `
+log_level: -4
 `
 
 	cfg := &Config{}
@@ -183,6 +185,7 @@ upstreams:
     target: ` + backend1URL.String() + `
   - host_name: backend2.local
     target: ` + backend2URL.String() + `
+log_level: -4
 `
 	gondola, err := NewGondola(strings.NewReader(data))
 	if err != nil {


### PR DESCRIPTION
# Description
Implement access log.

# Changes
- Implemented access log
- Updated  _examples to make it easier to verify operation
- Updated support go-version for vulnerability
- Fixed READEME
- Create a logger for application logging
- Fixed the problematic proxy test code 

# Impact range
Proxy startup and application log output

# Operational Requirements
Needs Go1.21.6

# Related Issue
#3

# Supplement
Various details are listed in the PR comments.

# References
- https://medium.com/@bless2k/implementing-a-logging-proxy-server-with-golang-d0c673ef1f56
- https://medium.com/ymedialabs-innovation/reverse-proxy-in-go-d26482acbcad
- https://qiita.com/tutuming/items/6006e1d8cf94bc40f8e8
- https://stackoverflow.com/questions/69276445/logging-all-http-request-and-response-from-done-through-an-http-client
- https://qiita.com/nakaryooo/items/8d12d284c9caceb9c947
- https://engineering.mercari.com/blog/entry/2018-12-05-105737/
- https://bmf-tech.com/posts/Go%E3%81%AEhttp.RoundTripper%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6
- https://stackoverflow.com/questions/70550180/measuring-reverse-proxy-response-times-in-go
- https://blog.joshsoftware.com/2021/05/25/simple-and-powerful-reverseproxy-in-go/