### PR TITLE
Support TLS

### DIFF
--- a/.github/bench_test.go
+++ b/.github/bench_test.go
@@ -1,7 +1,0 @@
-package gondola
-
-import "testing"
-
-func BenchmarkExample(b *testing.B) {
-	b.Skip("This is an example test codes.")
-}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.21.6' ]
+        go-version: [ '1.22.0' ]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go ${{ matrix.go-version }}

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.21.6' ]
+        go-version: [ '1.22.0' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.21.6' ]
+        go-version: [ '1.22.0' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.21.6' ]
+        go-version: [ '1.22.0' ]
     steps:
       - uses: actions/checkout@v4
       - name: Add hosts to /etc/hosts

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __debug_bin
 
 # _examples
 _examples/proxy/main
+_examples/proxy/certificates

--- a/_examples/Makefile
+++ b/_examples/Makefile
@@ -10,8 +10,12 @@ CURRENT_BRANCH_GIT_COMMIT_HASH := $(shell git rev-parse HEAD)
 .PHONY: up
 up: ## Run docker compose up
 	cd ../cmd && pwd && GOOS=linux GOARCH=amd64 go build -o ../_examples/proxy/main
-	docker compose up
+	docker compose up --build
 
 .PHONY: down
 down: ## Run docker compose down
-	docker compose down
+	docker compose dow
+
+.PHONY: create-certs
+create-certs: ## Create certificates
+	cd ./proxy/certificates && go run $$(go env GOROOT)/src/crypto/tls/generate_cert.go -rsa-bits 2048 -host localhost

--- a/_examples/README.md
+++ b/_examples/README.md
@@ -15,8 +15,9 @@ sudo vim /etc/hosts
 
 ## Start a gondola
 ```sh
+make create-cert
 make up
 ```
 
 ## Access to a backend server
-`backend1.local` and `backend2.local` are available.
+`https://backend1.local` and `https://backend2.local` are available.

--- a/_examples/backend1/Dockerfile
+++ b/_examples/backend1/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.6-alpine
+FROM golang:1.22.0-alpine
 
 WORKDIR /app
 

--- a/_examples/backend1/go.mod
+++ b/_examples/backend1/go.mod
@@ -1,3 +1,3 @@
 module github.com/bmf-san/gondola/_examples/backend
 
-go 1.21
+go 1.22.0

--- a/_examples/backend2/Dockerfile
+++ b/_examples/backend2/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.6-alpine
+FROM golang:1.22.0-alpine
 
 WORKDIR /app
 

--- a/_examples/backend2/go.mod
+++ b/_examples/backend2/go.mod
@@ -1,3 +1,3 @@
 module github.com/bmf-san/gondola/_examples/backend
 
-go 1.21
+go 1.22.0

--- a/_examples/docker-compose.yml
+++ b/_examples/docker-compose.yml
@@ -18,3 +18,6 @@ services:
           context: ./proxy
       ports:
           - "80:80"
+          - "443:443"
+      volumes:
+        - ./certificates:/certificates

--- a/_examples/proxy/Dockerfile
+++ b/_examples/proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.6-alpine
+FROM golang:1.22.0-alpine
 
 WORKDIR /app
 

--- a/_examples/proxy/config.yaml
+++ b/_examples/proxy/config.yaml
@@ -1,7 +1,9 @@
 proxy:
-  port: 80
+  port: 443
   read_header_timeout: 2000
   shutdown_timeout: 3000
+  tls_cert_path: certificates/cert.pem
+  tls_key_path: certificates/key.pem
 upstreams:
   - host_name: backend1.local
     target: http://backend1:8081 # backend1　is the name of the container

--- a/config.go
+++ b/config.go
@@ -13,6 +13,13 @@ type Proxy struct {
 	Port              string `yaml:"port"`
 	ReadHeaderTimeout int    `yaml:"read_header_timeout"`
 	ShutdownTimeout   int    `yaml:"shutdown_timeout"`
+	TLSCertPath       string `yaml:"tls_cert_path"`
+	TLSKeyPath        string `yaml:"tls_key_path"`
+}
+
+// IsEnableTLS returns true if the proxy server is configured to use TLS.
+func (p *Proxy) IsEnableTLS() bool {
+	return p.TLSCertPath != "" && p.TLSKeyPath != ""
 }
 
 // Upstream is a struct that represents a backend server.

--- a/config_test.go
+++ b/config_test.go
@@ -6,12 +6,52 @@ import (
 	"testing"
 )
 
+func TestIsEnableTLS(t *testing.T) {
+	cases := []struct {
+		name     string
+		item     *Proxy
+		expected bool
+	}{
+		{
+			name:     "TLSCertPath and TLSKeyPath are empty",
+			item:     &Proxy{},
+			expected: false,
+		},
+		{
+			name:     "TLSCertPath is empty",
+			item:     &Proxy{TLSKeyPath: "key"},
+			expected: false,
+		},
+		{
+			name:     "TLSKeyPath is empty",
+			item:     &Proxy{TLSCertPath: "cert"},
+			expected: false,
+		},
+		{
+			name:     "TLSCertPath and TLSKeyPath are not empty",
+			item:     &Proxy{TLSCertPath: "cert", TLSKeyPath: "key"},
+			expected: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := c.item.IsEnableTLS()
+			if actual != c.expected {
+				t.Fatalf("Expected %v, got %v", c.expected, actual)
+			}
+		})
+	}
+}
+
 func TestLoad(t *testing.T) {
 	data := `
 proxy:
   port: 8080
   read_header_timeout: 2000
   shutdown_timeout: 3000
+  tls_cert_path: /path/to/cert
+  tls_key_path: /path/to/key
 upstreams:
   - host_name: backend1.local
     target: http://backend1:8081
@@ -25,6 +65,8 @@ log_level: -4
 			Port:              "8080",
 			ReadHeaderTimeout: 2000,
 			ShutdownTimeout:   3000,
+			TLSCertPath:       "/path/to/cert",
+			TLSKeyPath:        "/path/to/key",
 		},
 		[]Upstream{
 			{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bmf-san/gondola
 
-go 1.21
+go 1.22.0
 
 require (
 	github.com/google/uuid v1.5.0

--- a/proxy.go
+++ b/proxy.go
@@ -118,12 +118,19 @@ func (g *Gondola) Run() {
 
 	// TODO: do health check for upstreams.
 
-	slog.Info("Runing server on port " + g.config.Proxy.Port + "...")
-
 	go func() {
-		if err := g.server.ListenAndServe(); err != http.ErrServerClosed {
-			slog.Error("Server stopped with error: " + err.Error())
-			return
+		if g.config.Proxy.IsEnableTLS() {
+			slog.Info("Running server on port " + g.config.Proxy.Port + " with TLS...")
+			if err := g.server.ListenAndServeTLS(g.config.Proxy.TLSCertPath, g.config.Proxy.TLSKeyPath); err != http.ErrServerClosed {
+				slog.Error("Server stopped with error: " + err.Error())
+				return
+			}
+		} else {
+			slog.Info("Running server on port " + g.config.Proxy.Port + "...")
+			if err := g.server.ListenAndServe(); err != http.ErrServerClosed {
+				slog.Error("Server stopped with error: " + err.Error())
+				return
+			}
 		}
 	}()
 


### PR DESCRIPTION
# Description
Support TLS.

# Changes
- Add config values for TLS
- Enabled to start the server with TLS
- Update go version to 1.22

# Impact range
Proxy startup

# Operational Requirements
Need go1.22

# Related Issue
https://github.com/bmf-san/gondola/issues/3

# Supplement
https://github.com/bmf-san/gondola/discussions/30