### PR TITLE
Support graceful shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A simple and flexible reverse proxy written in Go
 - Simple configuration file (YAML)
 - Static file hosting
 - Virtual host support
+- Graceful shutdown
 - Detailed access logs (nginx-compatible)
 - Structured access logs (JSON)
 - TLS/SSL support


### PR DESCRIPTION
# Description
This pull request introduces a new feature to support graceful shutdown in the proxy server. It adds a `Server` struct that encapsulates the HTTP server and provides methods for starting, stopping, and checking the shutdown status.

# ADR


# Changes
- **README.md**: Added "Graceful shutdown" to the list of features.
- **proxy.go**:
  - Imported the `sync` package.
  - Added the `Server` struct with fields for handling graceful shutdown.
  - Implemented `NewProxyServer`, `ListenAndServe`, `ListenAndServeTLS`, `Shutdown`, and `IsShutdown` methods for the `Server` struct.
  - Updated the `ProxyHandler` to include graceful shutdown logging.
- **proxy_test.go**:
  - Added a new test `TestGracefulShutdown` to verify the graceful shutdown behavior.
  - Imported necessary packages for the test.

# Impact range
- This change primarily affects the initialization and shutdown process of the proxy server.
- The new graceful shutdown feature ensures that ongoing requests are completed before the server shuts down.
- The addition of new methods and struct may impact any existing code that directly interacts with the HTTP server setup.

# Operational Requirements
- Ensure that the server is properly started using the new `Server` struct.
- Update any deployment scripts or documentation to reflect the new method of starting and stopping the server.
- Verify that the graceful shutdown process works as expected in various environments (e.g., development, staging, production).

# Related Issue
No related issues were mentioned.](https://github.com/bmf-san/gondola/issues/51)

# Supplement
<!--- Not obligatory -->
This change enhances the reliability and maintainability of the proxy server by ensuring proper handling of shutdown scenarios. The implementation follows best practices for graceful shutdown in Go.