### PR TITLE
Support fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A simple and flexible reverse proxy written in Go
 - Lightweight and fast execution
 - Simple configuration file (YAML)
 - Static file hosting
+- Fallback support
 - Virtual host support
 - Graceful shutdown
 - Detailed access logs (nginx-compatible)

--- a/_examples/README.md
+++ b/_examples/README.md
@@ -19,5 +19,21 @@ make create-cert
 make up
 ```
 
+# Demonstration
 ## Access to a backend server
 `https://backend1.local` and `https://backend2.local` are available.
+
+## Static Files and Fallback
+You can test static file hosting and fallback functionality:
+
+1. Normal static file access
+```
+https://backend1.local/public/index.html   # Successfully displays index.html
+https://backend1.local/public/example.html # Successfully displays example.html
+```
+
+2. Fallback demonstration
+```
+https://backend1.local/public/not-exist.html  # Access to a non-existent file
+```
+When accessing a non-existent file, it will redirect to the 404.html page specified in config.yaml (`fallback_path: /public/404.html`).

--- a/_examples/proxy/config.yaml
+++ b/_examples/proxy/config.yaml
@@ -7,6 +7,7 @@ proxy:
   static_files:
     - path: /public/
       dir: ./public
+      fallback_path: /public/404.html
 upstreams:
   - host_name: backend1.local
     target: http://backend1:8081 # backend1　is the name of the container

--- a/_examples/proxy/public/404.html
+++ b/_examples/proxy/public/404.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>404 - Page Not Found</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            text-align: center;
+            padding: 50px;
+        }
+        h1 {
+            color: #333;
+        }
+        .message {
+            color: #666;
+            margin: 20px 0;
+        }
+    </style>
+</head>
+<body>
+    <h1>404 - Page Not Found</h1>
+    <div class="message">
+        申し訳ありませんが、お探しのページは見つかりませんでした。
+    </div>
+    <div>
+        <a href="/">トップページに戻る</a>
+    </div>
+</body>
+</html>

--- a/config.go
+++ b/config.go
@@ -21,8 +21,9 @@ type Proxy struct {
 
 // StaticFile is a struct that represents a static file configuration.
 type StaticFile struct {
-	Path string `yaml:"path"`
-	Dir  string `yaml:"dir"`
+	Path         string `yaml:"path"`
+	Dir          string `yaml:"dir"`
+	FallbackPath string `yaml:"fallback_path"` // Path to fallback file when requested file is not found
 }
 
 // IsEnableTLS returns true if the proxy server is configured to use TLS.

--- a/config_test.go
+++ b/config_test.go
@@ -59,6 +59,7 @@ proxy:
   static_files:
     - path: /public/
       dir: testdata/public
+      fallback_path: custom_404.html
 upstreams:
   - host_name: backend1.local
     target: http://backend1:8081
@@ -76,8 +77,9 @@ log_level: -4
 			TLSKeyPath:        "/path/to/key",
 			StaticFiles: []StaticFile{
 				{
-					Path: "/public/",
-					Dir:  "testdata/public",
+					Path:         "/public/",
+					Dir:          "testdata/public",
+					FallbackPath: "custom_404.html",
 				},
 			},
 		},

--- a/testdata/static/404.html
+++ b/testdata/static/404.html
@@ -1,0 +1,1 @@
+custom 404 content

--- a/testdata/static/index.html
+++ b/testdata/static/index.html
@@ -1,0 +1,1 @@
+index content

--- a/testdata/static/subdir/test.txt
+++ b/testdata/static/subdir/test.txt
@@ -1,0 +1,1 @@
+subdir content

--- a/testdata/static/test.txt
+++ b/testdata/static/test.txt
@@ -1,0 +1,1 @@
+test content


### PR DESCRIPTION
# Description
This pull request introduces several enhancements and bug fixes, primarily focusing on adding fallback support for static file hosting.

# Changes
- **README.md**: Added "Fallback support" to the list of features.
- **_examples/README.md**: Added demonstration for static files and fallback functionality.
- **_examples/proxy/config.yaml**: Added `fallback_path` configuration.
- **_examples/proxy/public/404.html**: Created custom 404 error page.
- **config.go**: Added `FallbackPath` field to `StaticFile` struct.
- **config_test.go**: Updated tests to include `fallback_path`.
- **gondola.go**: Modified static file handler to support fallback file serving.
- **proxy_test.go**: Updated tests to validate the new fallback functionality.
- **testdata/static/404.html**: Added test data for custom 404 content.
- **testdata/static/index.html**: Added test data for index content.
- **testdata/static/subdir/test.txt**: Added test data for subdirectory content.
- **testdata/static/test.txt**: Added test data for static file content.

# Impact range
- Enhances the static file serving mechanism by providing a fallback option when requested files are not found.
- Updates the configuration file format to support fallback paths.
- Introduces new test cases and test data to validate the fallback functionality.

# Operational Requirements
- Ensure that the `fallback_path` is correctly specified in the `config.yaml` file.
- Deploy the updated version to verify that the fallback mechanism works as expected in the production environment.

# Related Issue
close [https://github.com/bmf-san/gondola/issues/46](https://github.com/bmf-san/gondola/issues/46)

# Supplement
- Documentation has been updated to reflect the new feature.
- Custom 404 error page is now available in the `_examples/proxy/public/` directory.
