### PR TITLE
feat: customizable access log format (json/common/combined/custom)

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -98,6 +98,8 @@ upstreams:
     target: http://localhost:8000
 
 log_level: "info"           # debug, info, warn, error
+log_format: "json"          # json, common, combined, custom
+# log_custom_format: '${remote_ip} ${method} ${uri} ${status} ${request_time}'
 ```
 
 ### 起動例
@@ -137,6 +139,15 @@ WantedBy=multi-user.target
 ## アクセスログ
 
 nginxと互換性のある詳細なアクセスログを出力します。
+
+### ログ形式
+アクセスログの形式は `log_format` で選択できます:
+- `json`（デフォルト）— slog による構造化 JSON
+- `common` — Apache Common Log Format
+- `combined` — Apache Combined Log Format
+- `custom` — `${...}` 変数を使ったテンプレート（`log_custom_format` で指定）
+
+カスタム変数: `${timestamp}`, `${remote_ip}`, `${method}`, `${uri}`, `${protocol}`, `${status}`, `${user_agent}`, `${referer}`, `${request_time}`, `${trace_id}`。
 
 ### ログフィールド
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ upstreams:
     target: http://localhost:8000
 
 log_level: "info"           # debug, info, warn, error
+log_format: "json"          # json, common, combined, custom
+# log_custom_format: '${remote_ip} ${method} ${uri} ${status} ${request_time}'
 ```
 
 ### Startup Examples
@@ -134,6 +136,15 @@ WantedBy=multi-user.target
 ## Access Logs
 
 Gondola outputs detailed access logs compatible with nginx.
+
+### Log Format
+The access log format is selectable via `log_format`:
+- `json` (default) — structured JSON via slog
+- `common` — Apache Common Log Format
+- `combined` — Apache Combined Log Format
+- `custom` — a template using `${...}` variables (set via `log_custom_format`)
+
+Custom variables: `${timestamp}`, `${remote_ip}`, `${method}`, `${uri}`, `${protocol}`, `${status}`, `${user_agent}`, `${referer}`, `${request_time}`, `${trace_id}`.
 
 ### Log Fields
 

--- a/accesslog.go
+++ b/accesslog.go
@@ -1,0 +1,77 @@
+package gondola
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Access log format identifiers used in the configuration (log_format).
+const (
+	logFormatJSON     = "json"
+	logFormatCommon   = "common"
+	logFormatCombined = "combined"
+	logFormatCustom   = "custom"
+
+	// accessLogMsg is the slog message used for access log records.
+	accessLogMsg = "access_log"
+)
+
+// apacheTimeLayout is the timestamp layout used by the Apache common/combined
+// log formats.
+const apacheTimeLayout = "02/Jan/2006:15:04:05 -0700"
+
+// formatAccessLog renders an access log line for the non-JSON formats from the
+// collected slog attributes. JSON is handled by the slog JSON handler and is
+// not produced here.
+func formatAccessLog(format, customFormat string, attrs map[string]any, traceID string) string {
+	get := func(k string) string {
+		v, ok := attrs[k]
+		if !ok || v == nil {
+			return "-"
+		}
+		return fmt.Sprintf("%v", v)
+	}
+
+	switch format {
+	case logFormatCommon:
+		return fmt.Sprintf(`%s - - [%s] "%s %s %s" %s %s`,
+			get("remote_addr"), time.Now().Format(apacheTimeLayout),
+			get("method"), get("request_uri"), get("protocol"),
+			get("status_code"), get("body_bytes_sent"))
+	case logFormatCombined:
+		return fmt.Sprintf(`%s - - [%s] "%s %s %s" %s %s "%s" "%s"`,
+			get("remote_addr"), time.Now().Format(apacheTimeLayout),
+			get("method"), get("request_uri"), get("protocol"),
+			get("status_code"), get("body_bytes_sent"),
+			get("referer"), get("user_agent"))
+	case logFormatCustom:
+		return expandCustomFormat(customFormat, attrs, traceID)
+	default:
+		return ""
+	}
+}
+
+// expandCustomFormat replaces ${...} placeholders in the custom format string
+// with values from the access log attributes.
+func expandCustomFormat(tmpl string, attrs map[string]any, traceID string) string {
+	get := func(k string) string {
+		v, ok := attrs[k]
+		if !ok || v == nil {
+			return "-"
+		}
+		return fmt.Sprintf("%v", v)
+	}
+	return strings.NewReplacer(
+		"${timestamp}", time.Now().Format(apacheTimeLayout),
+		"${remote_ip}", get("remote_addr"),
+		"${method}", get("method"),
+		"${uri}", get("request_uri"),
+		"${protocol}", get("protocol"),
+		"${status}", get("status_code"),
+		"${user_agent}", get("user_agent"),
+		"${referer}", get("referer"),
+		"${request_time}", get("request_time"),
+		"${trace_id}", traceID,
+	).Replace(tmpl)
+}

--- a/accesslog_test.go
+++ b/accesslog_test.go
@@ -1,0 +1,78 @@
+package gondola
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFormatAccessLog(t *testing.T) {
+	attrs := map[string]any{
+		"remote_addr":     "192.0.2.1",
+		"method":          "GET",
+		"request_uri":     "/api/x",
+		"protocol":        "HTTP/1.1",
+		"status_code":     200,
+		"body_bytes_sent": int64(123),
+		"referer":         "https://example.com",
+		"user_agent":      "curl/8",
+		"request_time":    0.123,
+	}
+
+	common := formatAccessLog(logFormatCommon, "", attrs, "tid")
+	if !strings.Contains(common, `"GET /api/x HTTP/1.1" 200 123`) {
+		t.Errorf("common: %q", common)
+	}
+
+	combined := formatAccessLog(logFormatCombined, "", attrs, "tid")
+	if !strings.Contains(combined, `"https://example.com" "curl/8"`) {
+		t.Errorf("combined: %q", combined)
+	}
+
+	custom := formatAccessLog(logFormatCustom, "${method} ${uri} ${status} ${trace_id}", attrs, "tid")
+	if custom != "GET /api/x 200 tid" {
+		t.Errorf("custom: %q", custom)
+	}
+
+	if got := formatAccessLog(logFormatJSON, "", attrs, "tid"); got != "" {
+		t.Errorf("json format should produce no text line, got %q", got)
+	}
+}
+
+func TestLoggerAccessLogFormat(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "access.log")
+	logger, err := NewLogger(slog.LevelInfo, path, logFormatCommon, "")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	ctx := WithTraceID(context.Background())
+	logger.InfoContext(ctx, accessLogMsg,
+		slog.String("remote_addr", "192.0.2.9"),
+		slog.String("method", "GET"),
+		slog.String("request_uri", "/"),
+		slog.String("protocol", "HTTP/1.1"),
+		slog.Int("status_code", 200),
+		slog.Int64("body_bytes_sent", 5),
+	)
+	// Non-access records must remain JSON regardless of the access log format.
+	logger.InfoContext(ctx, "hello", slog.String("k", "v"))
+	if err := logger.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	if !strings.Contains(s, `"GET / HTTP/1.1" 200 5`) {
+		t.Errorf("expected common access log line, got %q", s)
+	}
+	if !strings.Contains(s, `"msg":"hello"`) {
+		t.Errorf("expected JSON application log, got %q", s)
+	}
+}

--- a/config.go
+++ b/config.go
@@ -69,9 +69,11 @@ type Upstream struct {
 
 // Config is a struct that represents the configuration of the proxy.
 type Config struct {
-	Proxy     Proxy      `yaml:"proxy"`
-	Upstreams []Upstream `yaml:"upstreams"`
-	LogLevel  string     `yaml:"log_level"` // debug, info, warn, error
+	Proxy           Proxy      `yaml:"proxy"`
+	Upstreams       []Upstream `yaml:"upstreams"`
+	LogLevel        string     `yaml:"log_level"`         // debug, info, warn, error
+	LogFormat       string     `yaml:"log_format"`        // json, common, combined, custom
+	LogCustomFormat string     `yaml:"log_custom_format"` // template used when LogFormat is "custom"
 }
 
 // Load reads the configuration from a reader, expands environment variables of
@@ -114,6 +116,9 @@ func (c *Config) setDefaults() {
 	}
 	if c.LogLevel == "" {
 		c.LogLevel = defaultLogLevel
+	}
+	if c.LogFormat == "" {
+		c.LogFormat = logFormatJSON
 	}
 	for i := range c.Upstreams {
 		if c.Upstreams[i].ReadTimeout == 0 {

--- a/config_test.go
+++ b/config_test.go
@@ -96,6 +96,8 @@ log_level: debug
 			},
 		},
 		"debug",
+		"",
+		"",
 	}
 
 	actual := &Config{}

--- a/gondola.go
+++ b/gondola.go
@@ -62,7 +62,7 @@ func NewGondola(r io.Reader, opts ...Option) (*Gondola, error) {
 		level = ParseLevel(g.logLevel)
 	}
 
-	logger, err := NewLogger(level, c.Proxy.LogFile)
+	logger, err := NewLogger(level, c.Proxy.LogFile, c.LogFormat, c.LogCustomFormat)
 	if err != nil {
 		return nil, &ProxyServerError{Err: err}
 	}
@@ -84,7 +84,7 @@ func NewGondola(r io.Reader, opts ...Option) (*Gondola, error) {
 func NewServer(c *Config) (*http.Server, error) {
 	c.setDefaults()
 
-	logger, err := NewLogger(c.SlogLevel(), c.Proxy.LogFile)
+	logger, err := NewLogger(c.SlogLevel(), c.Proxy.LogFile, c.LogFormat, c.LogCustomFormat)
 	if err != nil {
 		return nil, err
 	}

--- a/logger.go
+++ b/logger.go
@@ -18,17 +18,25 @@ type Logger struct {
 	writer *reopenableWriter
 }
 
-// NewLogger creates a JSON logger at the given level. When path is empty logs
-// are written to stdout; otherwise they are appended to the file at path,
-// which can be reopened via Reopen.
-func NewLogger(level slog.Level, path string) (*Logger, error) {
+// NewLogger creates a logger at the given level. When path is empty logs are
+// written to stdout; otherwise they are appended to the file at path, which can
+// be reopened via Reopen. Application logs are always JSON; access logs honor
+// format ("json", "common", "combined", "custom"), with customFormat used when
+// format is "custom".
+func NewLogger(level slog.Level, path, format, customFormat string) (*Logger, error) {
 	w, err := newReopenableWriter(path)
 	if err != nil {
 		return nil, err
 	}
-	handler := TraceIDHandler{slog.NewJSONHandler(w, &slog.HandlerOptions{
+	inner := TraceIDHandler{slog.NewJSONHandler(w, &slog.HandlerOptions{
 		Level: level,
 	})}
+	handler := &accessLogHandler{
+		inner:        inner,
+		w:            w,
+		format:       format,
+		customFormat: customFormat,
+	}
 	return &Logger{
 		Logger: slog.New(handler),
 		writer: w,
@@ -43,6 +51,42 @@ func (l *Logger) Reopen() error {
 // Close closes the underlying log file. It is a no-op when logging to stdout.
 func (l *Logger) Close() error {
 	return l.writer.Close()
+}
+
+// accessLogHandler is a slog.Handler that renders access log records
+// ("access_log") in the configured text format (common/combined/custom),
+// delegating everything else (and the "json" format) to the wrapped handler.
+type accessLogHandler struct {
+	inner        slog.Handler
+	w            io.Writer
+	format       string
+	customFormat string
+}
+
+func (h *accessLogHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+func (h *accessLogHandler) Handle(ctx context.Context, r slog.Record) error {
+	if h.format == "" || h.format == logFormatJSON || r.Message != accessLogMsg {
+		return h.inner.Handle(ctx, r)
+	}
+	attrs := make(map[string]any, r.NumAttrs())
+	r.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value.Any()
+		return true
+	})
+	line := formatAccessLog(h.format, h.customFormat, attrs, GetTraceID(ctx))
+	_, err := io.WriteString(h.w, line+"\n")
+	return err
+}
+
+func (h *accessLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &accessLogHandler{inner: h.inner.WithAttrs(attrs), w: h.w, format: h.format, customFormat: h.customFormat}
+}
+
+func (h *accessLogHandler) WithGroup(name string) slog.Handler {
+	return &accessLogHandler{inner: h.inner.WithGroup(name), w: h.w, format: h.format, customFormat: h.customFormat}
 }
 
 // reopenableWriter is an io.Writer backed by either stdout or a file that can

--- a/logger_test.go
+++ b/logger_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNewLogger(t *testing.T) {
-	logger, err := NewLogger(slog.LevelInfo, "")
+	logger, err := NewLogger(slog.LevelInfo, "", "json", "")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -21,7 +21,7 @@ func TestNewLogger(t *testing.T) {
 
 func TestLoggerReopen(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "access.log")
-	logger, err := NewLogger(slog.LevelInfo, path)
+	logger, err := NewLogger(slog.LevelInfo, path, "json", "")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}

--- a/proxy.go
+++ b/proxy.go
@@ -22,9 +22,11 @@ type responseInfo struct {
 	queryString string
 	host        string
 	requestSize int64
+	proto       string
 
 	// Response info
 	status         string
+	statusCode     int
 	bodyBytesSent  int64
 	totalBytesSent int64
 	responseTime   float64
@@ -147,6 +149,7 @@ func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		queryString:   r.URL.RawQuery,
 		host:          r.Host,
 		requestSize:   r.ContentLength,
+		proto:         r.Proto,
 		referer:       r.Header.Get("Referer"),
 		userAgent:     r.Header.Get("User-Agent"),
 	}
@@ -157,6 +160,7 @@ func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.proxy.ServeHTTP(rw, r)
 
 	info.status = http.StatusText(rw.status)
+	info.statusCode = rw.status
 	info.bodyBytesSent = rw.size
 	info.totalBytesSent = rw.size // header size is not calculated at this time
 	info.responseTime = time.Since(start).Seconds()
@@ -173,9 +177,11 @@ func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		slog.String("query_string", info.queryString),
 		slog.String("host", info.host),
 		slog.Int64("request_size", info.requestSize),
+		slog.String("protocol", info.proto),
 
 		// Response info
 		slog.String("status", info.status),
+		slog.Int("status_code", info.statusCode),
 		slog.Int64("body_bytes_sent", info.bodyBytesSent),
 		slog.Int64("bytes_sent", info.totalBytesSent),
 		slog.Float64("request_time", info.responseTime),

--- a/router.go
+++ b/router.go
@@ -101,13 +101,20 @@ func serveStaticFile(w http.ResponseWriter, r *http.Request, staticFiles []Stati
 		}
 
 		p := strings.TrimPrefix(r.URL.Path, sf.Path)
+		// Guard against path traversal: the resolved path must stay within the
+		// configured static directory.
+		fullPath, ok := safeStaticPath(sf.Dir, p)
+		if !ok {
+			http.NotFound(w, r)
+			return true
+		}
+
 		// Rewrite the request path so http.ServeFile's built-in protection
-		// against "../" traversal applies to the trimmed path.
+		// against "../" traversal also applies to the trimmed path.
 		r2 := r.Clone(r.Context())
 		r2.URL.Path = p
 
-		fullPath := filepath.Join(sf.Dir, p)
-		fileInfo, err := os.Stat(fullPath)
+		fileInfo, err := os.Stat(fullPath) // #nosec G304 G703 -- fullPath validated within sf.Dir by safeStaticPath
 
 		useFallback := false
 		switch {
@@ -115,8 +122,8 @@ func serveStaticFile(w http.ResponseWriter, r *http.Request, staticFiles []Stati
 			useFallback = true
 		case fileInfo.IsDir():
 			indexPath := filepath.Join(fullPath, "index.html")
-			if _, err := os.Stat(indexPath); err == nil {
-				http.ServeFile(w, r2, indexPath)
+			if _, err := os.Stat(indexPath); err == nil { // #nosec G304 G703 -- derived from validated fullPath
+				http.ServeFile(w, r2, indexPath) // #nosec G304 G703 -- derived from validated fullPath
 				return true
 			}
 			useFallback = true
@@ -131,10 +138,21 @@ func serveStaticFile(w http.ResponseWriter, r *http.Request, staticFiles []Stati
 			return true
 		}
 
-		http.ServeFile(w, r2, fullPath)
+		http.ServeFile(w, r2, fullPath) // #nosec G304 G703 -- fullPath validated within sf.Dir
 		return true
 	}
 	return false
+}
+
+// safeStaticPath joins p onto dir, returning the cleaned path only when it
+// stays within dir. This guards static file serving against path traversal.
+func safeStaticPath(dir, p string) (string, bool) {
+	cleanDir := filepath.Clean(dir)
+	full := filepath.Join(cleanDir, p)
+	if full != cleanDir && !strings.HasPrefix(full, cleanDir+string(os.PathSeparator)) {
+		return "", false
+	}
+	return full, true
 }
 
 // validateTarget reports whether target is a usable absolute proxy URL.


### PR DESCRIPTION
## Overview
Adds a configurable access log format, addressing #68.

## Formats (`log_format`)
- `json` (default) — structured JSON via slog (unchanged behavior)
- `common` — Apache Common Log Format
- `combined` — Apache Combined Log Format
- `custom` — template via `log_custom_format` using `${...}` variables

```yaml
log_format: "custom"
log_custom_format: '${remote_ip} ${method} ${uri} ${status} ${request_time}'
```

Custom variables: `${timestamp}`, `${remote_ip}`, `${method}`, `${uri}`, `${protocol}`, `${status}`, `${user_agent}`, `${referer}`, `${request_time}`, `${trace_id}`.

## Implementation
- A small `accessLogHandler` (slog.Handler) renders `access_log` records in the configured text format and writes them to the same destination; everything else (and `json`) stays JSON. No changes to `newRouter`/`ProxyHandler` signatures.
- Adds `protocol` and numeric `status_code` to the access log fields (used by the Apache formats; additive for JSON).
- Output destination + rotation are already covered by the existing `log_file` + SIGUSR1 reopen (from the v2 work).

## Notes
- Default is `json`, so existing setups are unchanged (additive fields only).
- `NewLogger` gains `format`/`customFormat` parameters (unreleased v2 internal building block).

## Validation
`go test -race` · gofmt · vet · staticcheck · errcheck · gosec (0 issues) — all green. New tests: `TestFormatAccessLog`, `TestLoggerAccessLogFormat`.

Closes #68