### PR TITLE
docs: fix stale master-branch links in READMEs and CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,6 +3,6 @@
 1. Fork ([https://github.com/bmf-san/gondola/fork](https://github.com/bmf-san/gondola/fork))
 2. Create a feature branch
 3. Commit your changes
-4. Rebase your local changes against the master branch
+4. Rebase your local changes against the main branch
 5. Fix your codes if CI failed.
 6. Create new Pull Request

--- a/README-ja.md
+++ b/README-ja.md
@@ -1,4 +1,4 @@
-[English](https://github.com/bmf-san/gondola) [日本語](https://github.com/bmf-san/gondola/blob/master/README-ja.md)
+[English](README.md) [日本語](README-ja.md)
 
 # Gondola
 [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[English](https://github.com/bmf-san/gondola) [日本語](https://github.com/bmf-san/gondola/blob/master/README-ja.md)
+[English](README.md) [日本語](README-ja.md)
 
 # Gondola
 [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go)


### PR DESCRIPTION
## Summary

The language-switcher links in the READMEs pointed to a `master` branch that no longer exists (the default branch is `main`), so the Japanese README returned a 404. This replaces them with branch-independent relative links and corrects a stale `master` reference in the contributing guide.

## Changes

- `README.md` / `README-ja.md`: switch the `English` / `日本語` links to relative paths (`README.md`, `README-ja.md`) so they resolve on any branch and never 404.
- `.github/CONTRIBUTING.md`: "Rebase your local changes against the `master` branch" → `main` branch.

## Notes

No code changes; documentation only.
